### PR TITLE
Fix AWS SQS host example

### DIFF
--- a/backends/pubsub.md
+++ b/backends/pubsub.md
@@ -161,7 +161,7 @@ Url: `awssqs://sqs-queue-url`
 
 {{< highlight json >}}
 {
-	"host": ["awssqs://https://sqs.us-east-2.amazonaws.com/123456789012"],
+	"host": ["awssqs://sqs.us-east-2.amazonaws.com/123456789012"],
 	"disable_host_sanitize": true,
 	"extra_config": {
 		"backend/pubsub/subscriber": {


### PR DESCRIPTION
According to my experience trying to get an SQS connection to work, there should only be one protocol in this string.