### PR TITLE
fix install instructions for the integration cmd

### DIFF
--- a/developer/integration-tests.md
+++ b/developer/integration-tests.md
@@ -58,7 +58,7 @@ You must build the go binary that allows you to run the tests.
 To install the integration tests you only need to run the following lines in any machine or Docker container with go installed:
 
 {{< terminal title="Installing the integration tool" >}}
-go install github.com/krakendio/krakend-ce/cmd/krakend-integration@v{{< product latest_version >}}
+go install github.com/krakendio/krakend-ce/v2/cmd/krakend-integration@v{{< product latest_version >}}
 {{< /terminal >}}
 
 After this you should have a new binary `krakend-integration` in your PATH. To use it you will to execute:


### PR DESCRIPTION
the pkg name should point to the v2 version