### PR TITLE
Revise helm chart's Github link to active repo

### DIFF
--- a/deploying/kubernetes.md
+++ b/deploying/kubernetes.md
@@ -82,4 +82,5 @@ For a more step by step process see [this blog entry](/blog/krakend-on-kubernete
 
 ## Helm Chart
 
-There is no official Helm chart for KrakenD. But you can see as example [Mikescandy's contribution](https://github.com/mikescandy/krakend-helm)
+There is no official Helm chart for KrakenD. However, there is a Helm chart here
+tracking Krakend releases maintained by [Equinix Metal](https://github.com/equinixmetal-helm/krakend).


### PR DESCRIPTION
Mikescandy's repository at https://github.com/mikescandy/krakend-helm is not updated often (last update December 14, 2021) and uses the `latest` tag for the krakend image. There are 12 commits total here by 3 contributors.

The repo at https://github.com/equinixmetal-helm/krakend uses explicit version numbers and has regular releases and a full CI/CD pipeline set up vis GitHub Actions here: https://github.com/equinixmetal-helm/krakend/actions and the latest commit from 5 days ago.

Compare this https://github.com/mikescandy/krakend-helm/pulse/monthly with https://github.com/equinixmetal-helm/krakend/pulse/monthly