### PR TITLE
Add an array query string parameter example

### DIFF
--- a/endpoints/common-expression-language-cel.md
+++ b/endpoints/common-expression-language-cel.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2021-04-12
+lastmod: 2023-03-14
 date: 2019-01-24
 linktitle: "Conditional requests and responses"
 title: Conditional requests and responses with CEL


### PR DESCRIPTION
Greetings! 

This PR is the result of a question that popped up on Slack yesterday. It tweaks documentation for CEL syntax regarding multi-value query string parameters and adds an example that checks for a value in the array via CEL. It assumes array query string parameters follow the form `?foo[]=bar&foo[]=baz` but also includes a note on how to handle the `?foo=bar&foo=baz` use case. 

Let me know what you think. I'm happy to change it up if you need it. Thanks!